### PR TITLE
Fix buffer overflow issue

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,15 +28,13 @@ library(magrittr)
 
 ## Installation
 
-<!--
 You can install the released version of diffmatchpatch from [CRAN](https://CRAN.R-project.org) with:
 
 ``` r
 install.packages("diffmatchpatch")
 ```
--->
 
-Currently only the development version of this library is available and can be installed directly from [GitHub](https://github.com/) with:
+The development version of this library can be installed directly from [GitHub](https://github.com/) with:
 
 ```r
 # install.packages("devtools")

--- a/README.md
+++ b/README.md
@@ -17,16 +17,15 @@ library.
 
 ## Installation
 
-<!--
-You can install the released version of diffmatchpatch from [CRAN](https://CRAN.R-project.org) with:
+You can install the released version of diffmatchpatch from
+[CRAN](https://CRAN.R-project.org) with:
 
 ``` r
 install.packages("diffmatchpatch")
 ```
--->
 
-Currently only the development version of this library is available and
-can be installed directly from [GitHub](https://github.com/) with:
+The development version of this library can be installed directly from
+[GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")

--- a/inst/include/diff_match_patch.h
+++ b/inst/include/diff_match_patch.h
@@ -684,7 +684,8 @@ class diff_match_patch {
     for (typename Diffs::iterator cur_diff = diffs.begin(); cur_diff != diffs.end(); ++cur_diff) {
       string_t text;
       for (int y = 0; y < (int)(*cur_diff).text.length(); y++) {
-        const LinePtr& lp = lineArray[static_cast<size_t>((*cur_diff).text[y])];
+          typedef typename std::make_unsigned<typename string_t::value_type>::type unsigned_value_type;
+          const LinePtr& lp = lineArray[static_cast<size_t>(static_cast<unsigned_value_type>((*cur_diff).text[y]))];
         text.append(lp.first, lp.second);
       }
       (*cur_diff).text.swap(text);


### PR DESCRIPTION
I had occasional issues with longer string comparisons where `std::bad_alloc()` errors would pop up, and would often kill the R session completely.

Today I noticed that the [STL variant repo](https://github.com/leutloff/diff-match-patch-cpp-stl) recently accepted a [pull request that fixed a buffer overflow issue](https://github.com/leutloff/diff-match-patch-cpp-stl/pull/19), which seemed similar to what I was experiencing with longer strings.

I made the same change on this branch in my fork, reinstalled the library in R from this branch, and now I'm not getting any `std::bad_alloc()` errors. 

I also noticed that the package is now available on CRAN, so I uncommented the CRAN installation instructions in `README.Rmd` and generated `README.md` accordingly.

Thanks for this library, I've found it very useful!